### PR TITLE
Remove the required state of sauce app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Required fields for upload are:
 * sauce_username
 * sauce_access_key
 
+Optional fields include:
+* sauce_app_name
+* artifact_path
+* data_center_url
+
 ## How to use this Step
 
 Can be run directly with the [bitrise CLI](https://github.com/bitrise-io/bitrise),

--- a/step.sh
+++ b/step.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-if [[ -z $sauce_app_name ]]; then
-  echo "SAUCE_APP_NAME environment variable must be set for this workflow!"
-  exit 1
-fi
-
-if [[ -z $artifact_path ]]; then
+if [ -z $artifact_path ] && [ -n "$sauce_app_name" ]; then
   artifact_path=$(if [[ $sauce_app_name =~ ".apk" ]]; then
     echo $BITRISE_APK_PATH;
   elif [[ $sauce_app_name =~ ".aab" ]]; then
@@ -16,8 +11,25 @@ if [[ -z $artifact_path ]]; then
   elif [[ $sauce_app_name =~ ".zip" ]]; then
     echo $BITRISE_XCARCHIVE_ZIP_PATH;
   else
-    echo "Your application name does not contain a valid extension (.apk, .aab, .ipa, or .zip).";
-    echo "Please update your sauce_app_name input value, or set your own artifact_path.";
+    echo "Your 'sauce_app_name' either does not contain a valid extension (.apk, .aab, .ipa, or .zip).";
+    echo "or does not match the build that was produced in this workflow";
+    echo "Please update your 'sauce_app_name' value or set your own artifact_path.";
+    exit 1;
+  fi)
+fi
+
+if [[ -z $artifact_path ]] && [[ -z $sauce_app_name ]]; then
+  artifact_path=$(if [[ -n "$BITRISE_APK_PATH" ]]; then
+    echo $BITRISE_APK_PATH;
+  elif [[ -n "$BITRISE_AAB_PATH" ]]; then
+    echo $BITRISE_AAB_PATH; 
+  elif [[ -n "$BITRISE_IPA_PATH" ]]; then
+    echo $BITRISE_IPA_PATH;
+  elif [[ -n "$BITRISE_XCARCHIVE_ZIP_PATH" ]]; then
+    echo $BITRISE_XCARCHIVE_ZIP_PATH;
+  else
+    echo "We attempted to find a valid build since 'artifact_path' and 'sauce_app_name' were not provided, but could not find one.";
+    echo "Please provide a .apk, .aab, .ipa, or .zip within this workflow or provide a custom 'artifact_path'.";
     exit 1;
   fi)
 fi
@@ -26,9 +38,17 @@ if [[ -z $data_center_endpoint ]]; then
   data_center_endpoint="https://api.us-west-1.saucelabs.com/v1/storage/upload"
 fi
 
-curl --location --request POST \
-  --url "$data_center_endpoint" \
-  --user "$sauce_username:$sauce_access_key" \
-  --form "payload=@$artifact_path"\
-  --form "name=$sauce_app_name" \
-  --fail
+if [[ -z $sauce_app_name ]]; then
+  curl --location --request POST \
+    --url "$data_center_endpoint" \
+    --user "$sauce_username:$sauce_access_key" \
+    --form "payload=@$artifact_path"\
+    --fail
+else
+  curl --location --request POST \
+    --url "$data_center_endpoint" \
+    --user "$sauce_username:$sauce_access_key" \
+    --form "payload=@$artifact_path"\
+    --form "name=$sauce_app_name" \
+    --fail
+fi

--- a/step.yml
+++ b/step.yml
@@ -14,16 +14,24 @@ summary: |
 description: |
   Upload your build file to Sauce Labs for remote device testing.
   Requires an APK, AAB, IPA, or ZIP file within the workflow, Sauce Labs username, access key, and file name.
-  You can optionally provide a build path and request url.
+  You can optionally provide a file name, build path, or request url.
 
   Required fields are:
   - sauce_username
   - sauce_access_key
-  - sauce_app_name
 
   Optional fields are:
+  - sauce_app_name
   - artifact_path
   - data_center_url
+
+  Note: If both `sauce_app_name` and `artifact_path` are missing, a valid .apk, .aab, .ipa, or .zip will attempt to be found.
+  The script will automatically search using the default Env Vars (in descending order):
+  - BITRISE_APK_PATH
+  - BITRISE_AAB_PATH
+  - BITRISE_IPA_PATH
+  - BITRISE_XCARCHIVE_ZIP_PATH
+  If both optional fields are null and no builds are found using the above, the workflow will fail.
 website: https://github.com/camseda/bitrise-step-upload-to-sauce-labs
 source_code_url: https://github.com/camseda/bitrise-step-upload-to-sauce-labs
 support_url: https://github.com/camseda/bitrise-step-upload-to-sauce-labs/issues
@@ -38,12 +46,6 @@ type_tags:
 is_always_run: false
 is_skippable: false
 run_if: ""
-
-deps:
-  brew:
-    - name: git
-  apt_get:
-    - name: git
 
 toolkit:
   bash:
@@ -69,21 +71,20 @@ inputs:
       title: Sauce Labs App Name
       summary: Your Sauce Labs application name and extension.
       description: |
-        This is translated to the File Name in Sauce Labs (and must include the file extension). The extension is used to automatically set the `artifact_path`.
+        This is translated to the File Name in Sauce Labs (and must include the file extension).
+        If `sauce_app_name` is included and `artifact_path` is null, the extension is used to search the workflow set it automatically.
 
         Sauce Lab's File Name can be used to activate a specific app with the `filename` flag in your Capabilities
         rather than using the File ID automatically generated on upload - `storage:filename=<fileName>.<ext>`.
         A JavaScript example would be: `caps['app'] = 'storage:filename=TestApplication.apk';`
-      is_required: true
+      is_required: false
   - artifact_path:
     opts:
-      title: The absolute APK, AAB, IPA, or ZIP path
-      summary: Leave empty to use an automatically generated artifact_path.
+      title: The absolute path to your file
+      summary: Leave empty to use an automatically generated artifact_path for an APK, AAB, IPA, or ZIP file
       description: |
-        Generated automatically based on the Sauce Lab application's name set in `sauce_app_name`.
-        The extension will be used to gather the `BITRISE_APK_PATH`, `BITRISE_AAB_PATH`, `BITRISE_IPA_PATH`, or `BITRISE_XCARCHIVE_ZIP_PATH`.
-
-        If you're uploading a file in a format other than .apk, .aab, .ipa, or .zip, you will need to provide a value for `artifact_path`.
+        Generated automatically if `sauce_app_name` is set and contains a valid extension.
+        If you don't supply `sauce_app_name`, provide an `artifact_path`, or upload a file format other than .apk, .aab, .ipa, or .zip, you will need to provide a value here.
       is_required: false
   - data_center_url:
     opts:


### PR DESCRIPTION
Removing the requirement of the `sauce_app_name` field:
- Updating the README and description of the step to reflect these changes (specifically that the step may fail if no builds are detected within the workflow)
- Adding a secondary conditional (can be improved by embedding it within the first conditional) to detect a build if none of the optional env vars are detected
- Adds a conditional to the cURL that will fire off with or without the `name` field if `sauce_app_name` is or is not present